### PR TITLE
Cut nova requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=7.1.0",
-        "laravel/nova": ">=1.0"
+        "php": ">=7.1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Causes issues with `composer require [this package]`.
Also semi-redundant, as nova is an implied requirement from the repo name.