### PR TITLE
Fix tool class no longer Metable

### DIFF
--- a/src/ResourceGroupMenu.php
+++ b/src/ResourceGroupMenu.php
@@ -3,9 +3,9 @@
 namespace SaintSystems\Nova\ResourceGroupMenu;
 
 use Laravel\Nova\Nova;
-use Laravel\Nova\Tool;
+use Laravel\Nova\Card;
 
-class ResourceGroupMenu extends Tool
+class ResourceGroupMenu extends Card
 {
     /**
      * Perform any tasks that need to happen when the tool is booted.


### PR DESCRIPTION
Fixes #22 

Tested this change with Nova 3.19 and changing to `Card` extension makes it render same as before.

This could be used as a temporary solution until you rework it to use the changed Tool class and probably best to replace meta usage with view data variables.